### PR TITLE
Bump protobuf requirement to <7,>=3.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.7"
 dependencies = [
     "google-auth<3,>=0.3.0",
     "grpcio<2,>=1.48.0",
-    "protobuf<6,>=3.20.0",
+    "protobuf<7,>=3.20.0",
     "requests<3,>=2.20.0",
 ]
 


### PR DESCRIPTION
https://github.com/home-assistant/core/pull/137736

fixes #5